### PR TITLE
fix: Address broken Release workflow login

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           package-name: zap2xml
       - name: Login into GitHub Container Registry
         if: ${{ steps.release.outputs.release_created }}
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+        run: echo ${{ github.token }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
       - name: Build Docker image
         if: ${{ steps.release.outputs.release_created }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,18 @@
 name: Release
+
 on:
   push:
     branches:
       - main
+
 jobs:
   build-tag-release:
     name: Build, tag, and release Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Setup release please
         uses: google-github-actions/release-please-action@v2
         id: release
@@ -18,15 +21,18 @@ jobs:
           release-type: simple
           changelog-path: CHANGELOG.md
           package-name: zap2xml
+
       - name: Login into GitHub Container Registry
         if: ${{ steps.release.outputs.release_created }}
-        run: echo ${{ github.token }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
       - name: Build Docker image
         if: ${{ steps.release.outputs.release_created }}
         run: |
           docker build \
           -t "ghcr.io/${GITHUB_REPOSITORY}:${{ steps.release.outputs.tag_name }}" \
           -t "ghcr.io/${GITHUB_REPOSITORY}:latest" .
+
       - name: Release Docker image
         if: ${{ steps.release.outputs.release_created }}
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
           package-name: zap2xml
       - name: Login into GitHub Container Registry
         if: ${{ steps.release.outputs.release_created }}
-        run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
       - name: Build Docker image
         if: ${{ steps.release.outputs.release_created }}
         run: |


### PR DESCRIPTION
### Description

Fix the broken  ghcr.io authentication in the main release workflow

The Release workflow's ghcr.io password secret has expired, as apparent by the failing workflow. See: https://github.com/jef/zap2xml/actions/runs/14231170494/job/39881969502#step:4:5

Instead, the workflow can use the auto-generated GITHUB_TOKEN to authenticate and publish the Docker image, as documented here: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret

This assumed the repo owner is using the default permissions for the GITHUB_TOKEN `Default access
(permissive)`
https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

### Testing

Unable to test, as I'm not the owner of the repo and the workflow will not publish the container under the owner's repo.