### PR TITLE
feat: Added category tags

### DIFF
--- a/src/xmltv.test.ts
+++ b/src/xmltv.test.ts
@@ -24,7 +24,7 @@ const mockData: GridApiResponse = {
           endTime: "2025-07-18T20:00:00Z",
           thumbnail: "p30687311_b_v13_aa",
           channelNo: "4.1",
-          filter: ["filter-news"],
+          filter: ["filter-news", "filter-sports"],
           seriesId: "SH05918266",
           rating: "TV-PG",
           flag: ["New"],
@@ -85,6 +85,12 @@ describe("buildXmltv", () => {
     );
   });
 
+  it("should include category information", () => {
+    const result = buildXmltv(mockData);
+    expect(result).toContain('<category lang="en">news</category>');
+    expect(result).toContain('<category lang="en">sports</category>');
+  });
+  
   it("should include rating information", () => {
     const result = buildXmltv(mockData);
     expect(result).toContain(
@@ -173,7 +179,7 @@ describe("buildXmltv", () => {
     expect(result).not.toContain("<sub-title>");
     expect(result).not.toContain("<desc>");
     expect(result).not.toContain("<rating>");
-    expect(result).not.toContain("<category>");
+    expect(result).not.toContain('<category lang="en">');
     expect(result).not.toContain("<episode-num");
     expect(result).not.toContain("<icon");
   });
@@ -269,6 +275,8 @@ describe("buildProgramsXml", () => {
     expect(result).toContain(
       "<desc>BIA performs; comic Zarna Garg; lifestyle contributor Lori Bergamotto; ABC News chief medical correspondent Dr. Tara Narula.</desc>",
     );
+    expect(result).toContain('<category lang="en">news</category>');
+    expect(result).toContain('<category lang="en">sports</category>');
     expect(result).toContain(
       '<rating system="MPAA"><value>TV-PG</value></rating>',
     );
@@ -336,7 +344,7 @@ describe("buildProgramsXml", () => {
     expect(result).not.toContain("<sub-title>");
     expect(result).not.toContain("<desc>");
     expect(result).not.toContain("<rating>");
-    expect(result).not.toContain("<category>");
+    expect(result).not.toContain('<category lange="en">');
     expect(result).not.toContain("<episode-num");
     expect(result).not.toContain("<icon");
   });

--- a/src/xmltv.ts
+++ b/src/xmltv.ts
@@ -78,6 +78,15 @@ export function buildProgramsXml(data: GridApiResponse): string {
         xml += `    <desc>${escapeXml(event.program.shortDesc)}</desc>\n`;
       }
 
+      if (event.filter && event.filter.length > 0) {
+        for (let i = 0; i < event.filter.length; i++) {
+          const category = event.filter[i].match(/^(filter)-(.*?)$/);
+          if (category) {
+            xml += `    <category lang="en">${category[2]}</category>`;
+          }
+        }
+      }
+      
       if (event.rating) {
         xml += `    <rating system="MPAA"><value>${escapeXml(
           event.rating,


### PR DESCRIPTION
### Description

Added functionality to provide categories within the system. Utilizes the filters provided by Gracenotes for events as categories for programme. Includes removal of 'filter-' identifier from all filters to provide conventional filter names. If no filter is provided in array, no category tag is added to programme. 

Includes the following error prevention:
- Provides no category in the event there is no filter tag provided in API response for an event.
- Provides no category in the event that the filter naming convention is changed by Gracenotes.

### Testing

- Manually pulled API response to verify contents of response to align test file modifications to API response expectation. 
- Updated test file to include verification of new tags.  
- Included instance of a second tag to verify array functionality. 
- Included modification of existing category tag checks of minimal for missing language identifier (following XMLTV standard) to ensure that tags issues still did not occur. 
