### PR TITLE
fix: exclude execution scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist
 
 compose.yaml
 xmltv.xml
+
+/run-zap2xml.sh
+/run-zap2xml.bat


### PR DESCRIPTION
### Description

The documentation currently suggests making `run-zap2xml.sh`/`run-zap2xml.bat` files in the repository directory to run it. It's a minor thing, but I think it's fair and cleaner if those are excluded from the git repository to avoid people accidentally committing their scripts or at least getting prompted to do so.

### Testing

This change makes it excluded my `run-zap2xml.sh` file.